### PR TITLE
add pypi opencv package to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 numpy >= 1.11.1
+opencv-python


### PR DESCRIPTION
opencv did not used to be on pypi and had to be built from source, so it was omitted from reqs. pypi has since added `opencv-python`.